### PR TITLE
Proposta sostituzione metodo deprecato

### DIFF
--- a/EsercitazioneSiw2019/newTest/persistence/Main.java
+++ b/EsercitazioneSiw2019/newTest/persistence/Main.java
@@ -2,6 +2,7 @@ package persistence;
 
 import model.Dipartimento;
 import persistence.dao.DipartimentoDao;
+import java.lang.reflect.InvocationTargetException;
 
 public class Main {
 	public static void main(String args[]) {		

--- a/EsercitazioneSiw2019/newTest/persistence/Main.java
+++ b/EsercitazioneSiw2019/newTest/persistence/Main.java
@@ -4,9 +4,11 @@ import model.Dipartimento;
 import persistence.dao.DipartimentoDao;
 
 public class Main {
-	public static void main(String args[]) {				
+	public static void main(String args[]) {		
+		
 		try {
-			Class.forName("org.postgresql.Driver").newInstance();
+			Class.forName("org.postgresql.Driver").getConstructor().newInstance();
+			
 			DataSource dataSource=new DataSource(
 					"jdbc:postgresql://localhost:5432/Segreteria2019",
 					"postgres","postgres");
@@ -19,10 +21,8 @@ public class Main {
 			dipDao.save(newDip);
 			
 			
-			
-			
-			
-		} catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
+		} catch (InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException
+				| NoSuchMethodException | SecurityException | ClassNotFoundException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}


### PR DESCRIPTION
Buongiorno prof, suggerisco la sostituzione del metodo Class.forName("org.postgresql.Driver").newInstance(); con Class.forName("org.postgresql.Driver").getConstructor().newInstance(); in quanto deprecato da java 9, questo ha comportato anche l'aggiunta di nuovi casi di eccezioni nel catch.